### PR TITLE
Expect Failure from Grammar.parse

### DIFF
--- a/bin/p6tags
+++ b/bin/p6tags
@@ -72,7 +72,7 @@ for @files -> $io {
     for $io.lines -> $line {
         next unless $line;
 
-        @tags.append: gather Purl6.parse( $line, :actions( Purl6::Actions.new( :$file ) ) );
+        @tags.append: gather try Purl6.parse( $line, :actions( Purl6::Actions.new( :$file ) ) );
 
     }  
 }


### PR DESCRIPTION
This is a fix for recent rakudo change
(9501edae4f73a970e3270e3b0336a7b3045d3329)

Note that the change will be reverted, but it does not hurt to adapt
this module anyway.